### PR TITLE
Report unsupported platform message to stderr rather than stdout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist
 *.o
+cabal-dev

--- a/Network/TLS/Extra/Certificate.hs
+++ b/Network/TLS/Extra/Certificate.hs
@@ -34,6 +34,12 @@ import Network.TLS (TLSCertificateUsage(..), TLSCertificateRejectReason(..))
 import Data.Time.Calendar
 import Data.List (find)
 
+#if defined(NOCERTVERIFY)
+
+import System.IO (hPutStrLn, stderr)
+
+#endif
+
 -- | combine many certificates checking function together.
 -- if one check fail, the whole sequence of checking is cuted short and return the
 -- reject reason.
@@ -52,8 +58,8 @@ certificateChecks checks x509s = do
  - for now, print a big fat warning (better than nothing) and returns true  -}
 certificateVerifyChain_ :: [X509] -> IO TLSCertificateUsage
 certificateVerifyChain_ _ = do
-	putStrLn "****************** certificate verify chain doesn't yet work on your platform **********************"
-	putStrLn "please consider contributing to the certificate package to fix this issue"
+	hPutStrLn stderr "****************** certificate verify chain doesn't yet work on your platform **********************"
+	hPutStrLn stderr "please consider contributing to the certificate package to fix this issue"
 	return CertificateUsageAccept
 
 #else


### PR DESCRIPTION
The main change here is to use 'hPutStrLn stderr' rather than 'putStrLn' for un-supported systems; I have a speccific reason for this (simplifies my workflow slightly), but it feels better to me to have this be written to stderr.

The other two changes are more cosmetic.

Thanks, Doug
